### PR TITLE
Use apt-get instead of apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE=debian:bookworm-slim
 FROM --platform=$TARGETPLATFORM ubuntu:22.04 AS builder
 # need to specify the ARG again to make it available in this stage
 ARG PIXI_VERSION
-RUN apt update && apt install -y curl
+RUN apt-get update && apt-get install -y curl
 # download the musl build since the gnu build is not available on aarch64
 RUN curl -Ls \
     "https://github.com/prefix-dev/pixi/releases/download/v${PIXI_VERSION}/pixi-$(uname -m)-unknown-linux-musl" \


### PR DESCRIPTION
```
#13 [linux/arm64 builder 2/4] RUN apt update && apt install -y curl
#13 0.621 
#13 0.622 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

```

Not that it matters...