### PR TITLE
Bump pixi version to 0.28.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PIXI_VERSION=0.28.0
+ARG PIXI_VERSION=0.28.1
 ARG BASE_IMAGE=debian:bookworm-slim
 
 FROM --platform=$TARGETPLATFORM ubuntu:24.04 AS builder


### PR DESCRIPTION
Self bump as 0.28.0 might give problems with older lockfiles.