### PR TITLE
Add `/root/.pixi/bin` to the `PATH` and associated test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,8 +141,12 @@ jobs:
       if: needs.version.outputs.push == 'true'
       run: |
         docker images
+        # Test the pixi binary is available
         docker run --rm ghcr.io/prefix-dev/pixi:${{ needs.version.outputs.new-version }}-${{ steps.image-variables.outputs.tag }} pixi --version
+        # Test end-to-end pixi workflow
         docker run --rm ghcr.io/prefix-dev/pixi:${{ needs.version.outputs.new-version }}-${{ steps.image-variables.outputs.tag }} sh -c "mkdir /app && cd /app && pixi init && pixi add python && pixi run python --version"
+        # Test pixi global binaries are in PATH
+        docker run --rm pixi-docker sh -c "pixi global install rsync && rsync --version"
     - name: Image digest
       run: echo ${{ steps.build.outputs.digest }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,4 @@ RUN /pixi --version
 
 FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 COPY --from=builder --chown=root:root --chmod=0555 /pixi /usr/local/bin/pixi
+ENV PATH="/root/.pixi/bin:${PATH}"


### PR DESCRIPTION
Fix #40 

This is fragile since it won't work if the user is modified, but at least it will make pixi global binaries available "by default" without any additional tweaks.