### PR TITLE
Add `cuda` 12.8.1 images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,6 @@ jobs:
          - ubuntu:jammy # 22.04
          - ubuntu:focal # 20.04
          # https://hub.docker.com/r/nvidia/cuda
-         - nvidia/cuda:12.6.3-base-ubuntu24.04
-         - nvidia/cuda:12.6.3-base-ubuntu22.04
-         - nvidia/cuda:12.6.3-base-ubuntu20.04
          - nvidia/cuda:12.8.1-base-ubuntu24.04
          - nvidia/cuda:12.8.1-base-ubuntu22.04
          - nvidia/cuda:12.8.1-base-ubuntu20.04

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,9 @@ jobs:
          - nvidia/cuda:12.6.3-base-ubuntu24.04
          - nvidia/cuda:12.6.3-base-ubuntu22.04
          - nvidia/cuda:12.6.3-base-ubuntu20.04
+         - nvidia/cuda:12.8.1-base-ubuntu24.04
+         - nvidia/cuda:12.8.1-base-ubuntu22.04
+         - nvidia/cuda:12.8.1-base-ubuntu20.04
     steps:
     - name: Checkout source
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ There are different tags for different base images available:
 - `latest` - based on `ubuntu:noble`
 - `focal` - based on `ubuntu:focal`
 - `bullseye` - based on `debian:bullseye`
-- `noble-cuda-12.6.3` - based on `nvidia/cuda:12.6.3-ubuntu24.04`
+- `noble-cuda-12.8.1` - based on `nvidia/cuda:12.8.1-base-ubuntu24.04`
 - ... and more
 
 ## Usage with shell-hook


### PR DESCRIPTION
Adds cuda 12.8.1 base images (https://hub.docker.com/r/nvidia/cuda/tags?name=12.8.1-base-ubuntu).