### PR TITLE
fix invalid readme pixi command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ WORKDIR /app
 RUN pixi run build
 # run the `install` command (or any other). This will also install the dependencies into `/app/.pixi`
 # assumes that you have a `prod` environment defined in your pixi.toml
-RUN pixi run install -e prod
+RUN pixi install -e prod
 # Create the shell-hook bash script to activate the environment
 RUN pixi shell-hook -e prod > /shell-hook.sh
 


### PR DESCRIPTION
it's just pixi install, not pixi run install.
maybe it would be better to just include the `example/Dockerfile`