### PR TITLE
Add Bash shell autocompletions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ RUN /pixi --version
 
 FROM --platform=$TARGETPLATFORM $BASE_IMAGE
 COPY --from=builder --chown=root:root --chmod=0555 /pixi /usr/local/bin/pixi
+RUN printf '\neval "$(pixi completion --shell bash)"\n' >> /root/.bashrc
 ENV PATH="/root/.pixi/bin:${PATH}"


### PR DESCRIPTION
* Add the Bash shell autocompletions to the `~/.bashrc` to allow for use of tab completions while using interactively.

This results in the built container image having

```console
# tail -n 2 ~/.bashrc 

eval "$(pixi completion --shell bash)"
```

If updating documentation:

- [N/A] Updated documentation in https://github.com/prefix-dev/pixi/blob/main/docs/deployment/container.md as well
