### PR TITLE
Fix TEST_IMAGE to use full image reference when pushing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
         path: ${{ steps.metadata.outputs.bake-file }}
     - name: Run tests
       env:
-        TEST_IMAGE: ${{ needs.version.outputs.push == 'true' && steps.build.outputs.digest || steps.build.outputs.imageid }}
+        TEST_IMAGE: ${{ needs.version.outputs.push == 'true' && format('ghcr.io/prefix-dev/pixi@{0}', steps.build.outputs.digest) || steps.build.outputs.imageid }}
       run: |
         docker images
         # Test the pixi binary is available


### PR DESCRIPTION
## Problem

CI is failing on main because the `Run tests` step uses a bare digest (`sha256:...`) which cannot be used with `docker run` when the image is pushed to the registry but not loaded locally.

The failing run: https://github.com/prefix-dev/pixi-docker/actions/runs/21145299950

Exit code 125 from Docker indicates the image cannot be found locally.

## Root Cause

When `push=true`:
- The image is pushed to the registry with `push: true`
- `load: false` - images are NOT loaded into the local Docker daemon
- `TEST_IMAGE` was set to just `steps.build.outputs.digest` (e.g., `sha256:abc123...`)
- But `docker run sha256:abc123...` doesn't work - Docker needs the full image reference

## Fix

Use the full image reference with the digest: `ghcr.io/prefix-dev/pixi@sha256:...`

This allows Docker to pull the image from the registry and run the tests.