### PR TITLE
feat: add `ca-certificates` to image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
          - debian:bullseye # 11
          # https://hub.docker.com/_/ubuntu
          - ubuntu:plucky # 25.04
-         - ubuntu:oracular # 24.10
          - ubuntu:noble # 24.04
          - ubuntu:jammy # 22.04
          - ubuntu:focal # 20.04
@@ -74,7 +73,6 @@ jobs:
                 "22.04": "jammy",
                 "20.04": "focal",
                 "24.04": "noble",
-                "24.10": "oracular",
                 "25.04": "plucky"
             }
             ubuntu_version_number = base_image.split("-ubuntu")[-1]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN curl -Ls \
 RUN /pixi --version
 
 FROM --platform=$TARGETPLATFORM $BASE_IMAGE
+RUN apt-get update && apt-get install -y ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder --chown=root:root --chmod=0555 /pixi /usr/local/bin/pixi
 RUN printf '\neval "$(pixi completion --shell bash)"\n' >> /root/.bashrc
 ENV PATH="/root/.pixi/bin:${PATH}"


### PR DESCRIPTION
Without that cargo isn't able to download crates. I wonder why that is not part of the base images.